### PR TITLE
Disable signing

### DIFF
--- a/SquishIt.Config.Mvc/SquishIt.Config.Mvc.csproj
+++ b/SquishIt.Config.Mvc/SquishIt.Config.Mvc.csproj
@@ -33,7 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>SquishIt.Config.Mvc.snk</AssemblyOriginatorKeyFile>

--- a/SquishIt.Config/Squishit.Config.csproj
+++ b/SquishIt.Config/Squishit.Config.csproj
@@ -33,7 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>SquishIt.Config.snk</AssemblyOriginatorKeyFile>
@@ -128,7 +128,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <PropertyGroup>
-    <PreBuildEvent>$(SolutionDir)\.nuget\sign-assembly $(SolutionDir)\packages\SquishIt.0.8.5\lib\SquishIt.Framework.dll</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Signing the assemblies just isn't going to be worth hassle of also pulling down the SqushIt source and building.
